### PR TITLE
Show approximate USD total without adding fee

### DIFF
--- a/clp-to-usd-paypal.php
+++ b/clp-to-usd-paypal.php
@@ -26,7 +26,11 @@ function mostrar_total_en_dolares($cart) {
 
 
     if (is_numeric($total_dolares)) {
-        $cart->add_fee('Total en dólares (aprox)', $total_dolares, false);
+        $label = sprintf(
+            __('Total en dólares (aprox): %s', 'clp-to-usd-paypal'),
+            wc_price($total_dolares, array('currency' => 'USD'))
+        );
+        $cart->add_fee($label, 0, false);
     }
 }
 add_action('woocommerce_cart_calculate_fees', 'mostrar_total_en_dolares');


### PR DESCRIPTION
## Summary
- display the converted USD amount as informational text
- keep order totals unchanged

## Testing
- `php -l clp-to-usd-paypal.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68416871434c8322b04d47596a939049